### PR TITLE
Add missing import for gym library

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A collection of environments for *autonomous driving* and tactical decision-maki
 ## Usage
 
 ```python
+import gym
 import highway_env
 
 env = gym.make("highway-v0")


### PR DESCRIPTION
Add missing import of gym library in Usage to avoid getting this error
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'gym' is not defined
```